### PR TITLE
Add support for Edgetpu M.2 PCIe

### DIFF
--- a/frigate/config.json
+++ b/frigate/config.json
@@ -21,7 +21,8 @@
   "host_network": false,
   "devices": [
     "/dev/bus/usb:/dev/bus/usb:rwm",
-    "/dev/dri/renderD128:/dev/dri/renderD128:rwm"
+    "/dev/dri/renderD128:/dev/dri/renderD128:rwm",
+     "/dev/apex_0:/dev/apex_0:rwm"
   ],
   "full_access": true,
   "environment": {


### PR DESCRIPTION
Add PCIe M.2 Edgetpu device.
I got mine working with this change and
    type: edgetpu
    device: pci
in the configuration