### PR TITLE
Update devices to new format to remove deprecation warning

### DIFF
--- a/frigate/config.json
+++ b/frigate/config.json
@@ -22,9 +22,9 @@
   },
   "host_network": false,
   "devices": [
-    "/dev/bus/usb:/dev/bus/usb:rwm",
-    "/dev/dri/renderD128:/dev/dri/renderD128:rwm",
-    "/dev/apex_0:/dev/apex_0:rwm"
+    "/dev/bus/usb",
+    "/dev/dri/renderD128",
+    "/dev/apex_0"
   ],
   "full_access": true,
   "environment": {

--- a/frigate_beta/config.json
+++ b/frigate_beta/config.json
@@ -22,9 +22,9 @@
   },
   "host_network": false,
   "devices": [
-    "/dev/bus/usb:/dev/bus/usb:rwm",
-    "/dev/dri/renderD128:/dev/dri/renderD128:rwm",
-    "/dev/apex_0:/dev/apex_0:rwm"
+    "/dev/bus/usb",
+    "/dev/dri/renderD128",
+    "/dev/apex_0"
   ],
   "full_access": true,
   "environment": {


### PR DESCRIPTION
Update devices to new format to remove deprecation warning:

`WARNING (MainThread) [supervisor.addons.validate] Add-on config 'devices' use a deprecated format, the new format uses a list of paths only. Please report this to the maintainer of Frigate NVR`

Corresponding code change in supervisor: https://github.com/home-assistant/supervisor/pull/2429/files#diff-9d9b42663129dffdf9ab9475772d2161c835d56d51ba861d73d93e9340980e74R137
