### PR TITLE
Fix usb access in addon config for Hassio supervisor 2021-2

### DIFF
--- a/frigate/config.json
+++ b/frigate/config.json
@@ -26,6 +26,7 @@
     "/dev/apex_0"
   ],
   "usb": true,
+  "full_access": true,
   "environment": {
     "CONFIG_FILE": "/config/frigate.yml"
   },

--- a/frigate/config.json
+++ b/frigate/config.json
@@ -22,11 +22,10 @@
   },
   "host_network": false,
   "devices": [
-    "/dev/bus/usb",
     "/dev/dri/renderD128",
     "/dev/apex_0"
   ],
-  "full_access": true,
+  "usb": true,
   "environment": {
     "CONFIG_FILE": "/config/frigate.yml"
   },

--- a/frigate_beta/config.json
+++ b/frigate_beta/config.json
@@ -22,11 +22,10 @@
   },
   "host_network": false,
   "devices": [
-    "/dev/bus/usb",
     "/dev/dri/renderD128",
     "/dev/apex_0"
   ],
-  "full_access": true,
+  "usb": true,
   "environment": {
     "CONFIG_FILE": "/data/options.json"
   },

--- a/frigate_beta/config.json
+++ b/frigate_beta/config.json
@@ -26,6 +26,7 @@
     "/dev/apex_0"
   ],
   "usb": true,
+  "full_access": true,
   "environment": {
     "CONFIG_FILE": "/data/options.json"
   },


### PR DESCRIPTION
Fixes blakeblackshear/frigate-hass-addons/issues/14

In and out the rabbit hole of debugging this I found the `usb` option in [the addon configuration](https://developers.home-assistant.io/docs/add-ons/configuration/) that does exactly what we need.

> usb | bool | no | If this is set to true, it would map the raw USB access /dev/bus/usb into add-on with plug&play support.

It also has a `video` option but [that's for video4linux and cec devices](https://github.com/home-assistant/supervisor/blob/c4f07025956f17121c2cdd4b3290c89323f0754e/supervisor/misc/hardware.py#L31) so not a replacement for `/dev/dri/renderD128`.

~As far as I can tell this addon doesn't need the `full_access` setting.
Removing this option from the addon settings removes the `Protection mode` option at all, so it's no longer something to worry about.~ It does need it, see comments.

I've tested this on my local HA installation

![Screenshot 2021-02-10 at 13 50 41](https://user-images.githubusercontent.com/19285728/107512350-0145e380-6ba7-11eb-8640-44982303c7d3.png)

![Screenshot 2021-02-10 at 13 50 47](https://user-images.githubusercontent.com/19285728/107512359-0440d400-6ba7-11eb-87b1-4e2333f1b1f9.png)

![Screenshot 2021-02-10 at 13 51 27](https://user-images.githubusercontent.com/19285728/107512419-19b5fe00-6ba7-11eb-93ee-b5f95fd22629.png)

👍 