### PR TITLE
Adding build.json

### DIFF
--- a/frigate/build.json
+++ b/frigate/build.json
@@ -1,0 +1,7 @@
+{
+  "build_from": {
+    "armv7": "blakeblackshear/frigate:0.8.4-arm7",
+    "aarch64": "blakeblackshear/frigate:0.8.4-aarch64",
+    "amd64": "blakeblackshear/frigate:0.8.4-amd64"
+  }
+}


### PR DESCRIPTION
Adding build.json to resolve broken installs on HA core-2021.3.0b5 / supervisor supervisor-2021.03.0