### PR TITLE
Add more /dev/apex_* and remove full hardware access

### DIFF
--- a/frigate/config.json
+++ b/frigate/config.json
@@ -24,12 +24,13 @@
   "devices": [
     "/dev/dri/renderD128",
     "/dev/apex_0",
+    "/dev/apex_1",
+    "/dev/apex_2",
     "/dev/dri/card0",
     "/dev/vchiq"
   ],
   "usb": true,
   "tmpfs": true,
-  "full_access": true,
   "environment": {
     "CONFIG_FILE": "/config/frigate.yml"
   },

--- a/frigate/config.json
+++ b/frigate/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Frigate NVR",
-  "version": "1.13",
+  "version": "1.14",
   "panel_icon": "mdi:cctv",
   "slug": "frigate",
   "description": "NVR with realtime local object detection for IP cameras",


### PR DESCRIPTION
No need to request full device access as per https://developers.home-assistant.io/docs/add-ons/configuration/ when usb and devices are populated.
- Added /dev/apex_[0-2] to https://github.com/blakeblackshear/frigate-hass-addons/blob/4256ca2731277dd9b84b02b42b91053414f144e4/frigate/config.json#L24
- Removed full device access request https://github.com/blakeblackshear/frigate-hass-addons/blob/4256ca2731277dd9b84b02b42b91053414f144e4/frigate/config.json#L32 as usb and devices values are populated
- Bumped to next version