### PR TITLE
Add support for Home Assistant reverse proxy urls

### DIFF
--- a/frigate_proxy/CHANGELOG.md
+++ b/frigate_proxy/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.2
+
+- Added support for Home Assistant Reverse Proxy urls
 ### 1.1
 
 - Allow access to side panel for non-admins

--- a/frigate_proxy/DOCS.md
+++ b/frigate_proxy/DOCS.md
@@ -13,6 +13,10 @@ This must be in the format `host:port`. The following are valid examples:
 - `frigate.local:5000`
 - `192.168.0.101:5000`
 
+## Option: `proxy_url`
+
+The `proxy_url` option should be set if you are running Home Assistant behind a reverse proxy (such as Traefik, Nginx, Caddy, etc.) and are using your own url. Enter the proxy url for you Home Assistant instance without http/s:// i.e. "hassio.example.com". This is not required for non-proxied Home Assistant/Nabu Case cloud integration. 
+
 ## Required Dependencies
 - Network access to running Frigate server
 

--- a/frigate_proxy/README.md
+++ b/frigate_proxy/README.md
@@ -2,7 +2,7 @@
 
 ![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
 
-This addon creates a proxy to a Frigate server run separately from Home Assistant so that you can have the benefit of access in the sidebar without running Frigate as an addon.
+This addon creates a proxy to a Frigate server run separately from Home Assistant so that you can have the benefit of access in the sidebar without running Frigate as an addon. This includes Ingress support, allowing access through Home Assistant without having to set up a separate reverse proxy for the Frigate server.
 
 Note that this addon does not run Frigate itself.
 

--- a/frigate_proxy/config.json
+++ b/frigate_proxy/config.json
@@ -26,10 +26,12 @@
   "full_access": false,
   "environment": {},
   "options": {
-    "server": "frigate.local:5000"
+    "server": "frigate.local:5000",
+    "proxy_url": "homeassistant.local:8123"
   },
   "schema": {
-    "server": "match(^.+:\\d+$)"
+    "server": "match(^.+:\\d+$)",
+    "proxy_url": "match(^.+:\\d+$)"
   },
   "services": [],
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],

--- a/frigate_proxy/rootfs/etc/cont-init.d/nginx.sh
+++ b/frigate_proxy/rootfs/etc/cont-init.d/nginx.sh
@@ -16,3 +16,12 @@ echo '{"server":"'"$server"'"}' \
     | tempio \
         -template /etc/nginx/templates/upstream.gtpl \
         -out /etc/nginx/includes/upstream.conf
+
+declare proxy_url
+
+proxy_url=$(bashio::config 'proxy_url')
+
+echo '{"proxy_url":"'"$proxy_url"'"}' \
+    | tempio \
+        -template /etc/nginx/templates/server_params.gtpl \
+        -out /etc/nginx/includes/server_params.conf

--- a/frigate_proxy/rootfs/etc/nginx/templates/server_params.gtpl
+++ b/frigate_proxy/rootfs/etc/nginx/templates/server_params.gtpl
@@ -1,0 +1,7 @@
+root            /dev/null;
+server_name     $hostname;
+
+add_header X-Content-Type-Options nosniff;
+add_header X-XSS-Protection "1; mode=block";
+add_header X-Robots-Tag none;
+add_header Content-Security-Policy "frame-ancestors {{ .proxy_url }}";


### PR DESCRIPTION
Added support for proxy urls for users running home assistant behind a reverse proxy. This requires the nginx-based proxy used by this addon to pass the "Content-Security-Policy" header with the url otherwise errors are thrown in Firefox, Chrome, and other browsers when attempting to view recordings, live streams, etc. through the addon.