### PR TITLE
Support 4 apex devices

### DIFF
--- a/frigate/config.yaml
+++ b/frigate/config.yaml
@@ -25,6 +25,7 @@ devices:
   - /dev/apex_0
   - /dev/apex_1
   - /dev/apex_2
+  - /dev/apex_3
   - /dev/dri/card0
   - /dev/vchiq
   - /dev/video10

--- a/frigate_beta/config.yaml
+++ b/frigate_beta/config.yaml
@@ -25,6 +25,7 @@ devices:
   - /dev/apex_0
   - /dev/apex_1
   - /dev/apex_2
+  - /dev/apex_3
   - /dev/dri/card0
   - /dev/vchiq
   - /dev/video10

--- a/frigate_fa/config.yaml
+++ b/frigate_fa/config.yaml
@@ -25,6 +25,7 @@ devices:
   - /dev/apex_0
   - /dev/apex_1
   - /dev/apex_2
+  - /dev/apex_3
   - /dev/dri/card0
   - /dev/vchiq
   - /dev/video10

--- a/frigate_fa_beta/config.yaml
+++ b/frigate_fa_beta/config.yaml
@@ -25,6 +25,7 @@ devices:
   - /dev/apex_0
   - /dev/apex_1
   - /dev/apex_2
+  - /dev/apex_3
   - /dev/dri/card0
   - /dev/vchiq
   - /dev/video10


### PR DESCRIPTION
This PR adds support for one more apex device.

I've upgraded my setup, and now have two Dual Edge TPU m.2 cards:

```
# docker exec -ti addon_ccab4aaf_frigate-fa sh -c "ls -l /dev/apex*"
crw-rw---- 1 root root 120, 0 May  4 15:17 /dev/apex_0
crw-rw---- 1 root root 120, 1 May  4 15:17 /dev/apex_1
crw-rw---- 1 root root 120, 2 May  4 15:17 /dev/apex_2
crw-rw---- 1 root root 120, 3 May  4 15:17 /dev/apex_3
```