### PR TITLE
Fix beta addons S6 overlay conflict

### DIFF
--- a/frigate_beta/config.yaml
+++ b/frigate_beta/config.yaml
@@ -8,6 +8,7 @@ url: "https://github.com/blakeblackshear/frigate"
 image: blakeblackshear/frigate
 startup: application
 boot: auto
+init: false
 webui: "http://[HOST]:[PORT:5000]/"
 watchdog: "http://[HOST]:[PORT:5000]/"
 ingress: true

--- a/frigate_fa_beta/config.yaml
+++ b/frigate_fa_beta/config.yaml
@@ -8,6 +8,7 @@ url: "https://github.com/blakeblackshear/frigate"
 image: blakeblackshear/frigate
 startup: application
 boot: auto
+init: false
 webui: "http://[HOST]:[PORT:5000]/"
 watchdog: "http://[HOST]:[PORT:5000]/"
 ingress: true


### PR DESCRIPTION
According to https://developers.home-assistant.io/blog/2022/05/12/s6-overlay-base-images/ now that we have s6 overlay v3 being used we need to disable the HA init so s6 handles it and maintains PID 1