### PR TITLE
Add port for go2rtc API

### DIFF
--- a/frigate_beta/CHANGELOG.md
+++ b/frigate_beta/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.12.0-beta3
+
+- Update to 0.12.0 Beta 3 [Release Notes](https://github.com/blakeblackshear/frigate/releases/tag/v0.12.0-beta3)
+
 ### 0.12.0-beta2
 
 - Update to 0.12.0 Beta 2 [Release Notes](https://github.com/blakeblackshear/frigate/releases/tag/v0.12.0-beta2)

--- a/frigate_beta/README.md
+++ b/frigate_beta/README.md
@@ -1,4 +1,4 @@
-# Home Assistant Add-on: Frigate Beta (0.11.0)
+# Home Assistant Add-on: Frigate Beta (0.12.0)
 
 Please reference the [release notes](https://github.com/blakeblackshear/frigate/releases) for breaking changes.
 

--- a/frigate_beta/config.yaml
+++ b/frigate_beta/config.yaml
@@ -16,11 +16,13 @@ ingress_port: 5000
 ingress_entry: /
 panel_admin: false
 ports:
+  8555/tcp: null
   8554/tcp: null
   5000/tcp: null
   1984/tcp: null
   1935/tcp: null
 ports_description:
+  8555/tcp: WebRTC
   8554/tcp: RTSP Restream
   5000/tcp: Web interface (Not required for Hass.io Ingress)
   1984/tcp: go2rtc API

--- a/frigate_beta/config.yaml
+++ b/frigate_beta/config.yaml
@@ -1,5 +1,5 @@
 name: Frigate Beta (0.12.0)
-version: 0.12.0-beta2
+version: 0.12.0-beta3
 panel_icon: "mdi:cctv"
 panel_title: Frigate
 slug: frigate-beta

--- a/frigate_beta/config.yaml
+++ b/frigate_beta/config.yaml
@@ -18,10 +18,12 @@ panel_admin: false
 ports:
   8554/tcp: null
   5000/tcp: null
+  1984/tcp: null
   1935/tcp: null
 ports_description:
   8554/tcp: RTSP Restream
   5000/tcp: Web interface (Not required for Hass.io Ingress)
+  1984/tcp: go2rtc API
   1935/tcp: RTMP streams
 host_network: false
 devices:

--- a/frigate_fa_beta/CHANGELOG.md
+++ b/frigate_fa_beta/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.12.0-beta3
+
+- Update to 0.12.0 Beta 3 [Release Notes](https://github.com/blakeblackshear/frigate/releases/tag/v0.12.0-beta3)
+
 ### 0.12.0-beta2
 
 - Update to 0.12.0 Beta 2 [Release Notes](https://github.com/blakeblackshear/frigate/releases/tag/v0.12.0-beta2)

--- a/frigate_fa_beta/README.md
+++ b/frigate_fa_beta/README.md
@@ -1,4 +1,4 @@
-# Home Assistant Add-on: Frigate (Full Access) Beta (0.11.0)
+# Home Assistant Add-on: Frigate (Full Access) Beta (0.12.0)
 
 Please reference the [release notes](https://github.com/blakeblackshear/frigate/releases) for breaking changes.
 

--- a/frigate_fa_beta/config.yaml
+++ b/frigate_fa_beta/config.yaml
@@ -16,11 +16,13 @@ ingress_port: 5000
 ingress_entry: /
 panel_admin: false
 ports:
+  8555/tcp: null
   8554/tcp: null
   5000/tcp: null
   1984/tcp: null
   1935/tcp: null
 ports_description:
+  8555/tcp: WebRTC
   8554/tcp: RTSP Restream
   5000/tcp: Web interface (Not required for Hass.io Ingress)
   1984/tcp: go2rtc API

--- a/frigate_fa_beta/config.yaml
+++ b/frigate_fa_beta/config.yaml
@@ -1,5 +1,5 @@
 name: Frigate (Full Access) Beta (0.12.0)
-version: 0.12.0-beta2
+version: 0.12.0-beta3
 panel_icon: "mdi:cctv"
 panel_title: Frigate
 slug: frigate-fa-beta

--- a/frigate_fa_beta/config.yaml
+++ b/frigate_fa_beta/config.yaml
@@ -18,10 +18,12 @@ panel_admin: false
 ports:
   8554/tcp: null
   5000/tcp: null
+  1984/tcp: null
   1935/tcp: null
 ports_description:
   8554/tcp: RTSP Restream
   5000/tcp: Web interface (Not required for Hass.io Ingress)
+  1984/tcp: go2rtc API
   1935/tcp: RTMP streams
 host_network: false
 tmpfs: true


### PR DESCRIPTION
It will be a common usecase for users to want to use the embedded go2rtc API with https://github.com/AlexxIT/WebRTC in lovelace so we need to allow the port to be mapped.