### PR TITLE
Allow the add-on to access the Home Assistant API

### DIFF
--- a/frigate_beta/config.yaml
+++ b/frigate_beta/config.yaml
@@ -15,6 +15,7 @@ ingress: true
 ingress_port: 5000
 ingress_entry: /
 panel_admin: false
+homeassistant_api: true
 ports:
   8555/tcp: 8555
   8555/udp: 8555

--- a/frigate_fa_beta/config.yaml
+++ b/frigate_fa_beta/config.yaml
@@ -15,6 +15,7 @@ ingress: true
 ingress_port: 5000
 ingress_entry: /
 panel_admin: false
+homeassistant_api: true
 ports:
   8555/tcp: 8555
   8555/udp: 8555


### PR DESCRIPTION
The go2rtc add-on has this access role by default ([ref](https://github.com/AlexxIT/hassio-addons/blob/51b9b74df11f63976146af6b515bb552e2d0ab62/go2rtc/config.yaml#L14)), and the real usefulness of it is to allow people to import some Nest and Tuya cameras that hasn't an RTSP interface by default into go2rtc/Frigate by using:

https://github.com/felipecrs/hass-expose-camera-stream-source#importing-home-assistant-cameras-to-go2rtc-andor-frigate

**Should only be merged when actually releasing the new version.**