### PR TITLE
Include video and usb in FA

### DIFF
--- a/frigate_fa_beta/config.yaml
+++ b/frigate_fa_beta/config.yaml
@@ -33,6 +33,8 @@ ports_description:
   1935/tcp: RTMP streams
 host_network: false
 tmpfs: true
+usb: true
+video: true
 full_access: true
 privileged:
   - SYS_ADMIN


### PR DESCRIPTION
It seems that the config still needs to have these exposed, otherwise protected mode is required to be disabled for the container to be able to access these.

Based on https://github.com/blakeblackshear/frigate/issues/5895#issuecomment-1493405392