### PR TITLE
Reduce capability SYS_ADMIN to PERFMON

### DIFF
--- a/frigate/config.yaml
+++ b/frigate/config.yaml
@@ -47,7 +47,7 @@ video: true
 tmpfs: true
 full_access: false
 privileged:
-  - SYS_ADMIN
+  - PERFMON
 environment:
   CONFIG_FILE: /config/frigate.yml
 schema:

--- a/frigate_beta/config.yaml
+++ b/frigate_beta/config.yaml
@@ -47,7 +47,7 @@ video: true
 tmpfs: true
 full_access: false
 privileged:
-  - SYS_ADMIN
+  - PERFMON
 environment:
   CONFIG_FILE: /config/frigate.yml
 schema:

--- a/frigate_fa/config.yaml
+++ b/frigate_fa/config.yaml
@@ -35,7 +35,7 @@ host_network: false
 tmpfs: true
 full_access: true
 privileged:
-  - SYS_ADMIN
+  - PERFMON
 environment:
   CONFIG_FILE: /config/frigate.yml
 schema:

--- a/frigate_fa_beta/config.yaml
+++ b/frigate_fa_beta/config.yaml
@@ -37,7 +37,7 @@ usb: true
 video: true
 full_access: true
 privileged:
-  - SYS_ADMIN
+  - PERFMON
 environment:
   CONFIG_FILE: /config/frigate.yml
 schema:


### PR DESCRIPTION
As it is now possible thanks to https://github.com/home-assistant/supervisor/pull/4259 which has been released since 2 weeks already to stable channel.

Most users should have it already.