### PR TITLE
Add support for SSL upstream frigate servers in frigate_proxy.

### DIFF
--- a/frigate_proxy/CHANGELOG.md
+++ b/frigate_proxy/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 1.4
+
+- Add support for HTTPS upstream servers
+  Note the breaking change to configuration which requires the protocol to be
+  specified in the server configuration: `http://frigate.local:5000` instead of
+  `frigate.local:5000`.
+
 ### 1.3
 
 - Set side panel name to Frigate

--- a/frigate_proxy/DOCS.md
+++ b/frigate_proxy/DOCS.md
@@ -8,10 +8,22 @@ Note that this addon does not run Frigate itself.
 
 The `server` option sets the address of the Frigate server.
 
-This must be in the format `host:port`. The following are valid examples:
+This must be in the format `http[s]://host:port`. The following are valid examples:
 
-- `frigate.local:5000`
-- `192.168.0.101:5000`
+- `http://frigate.local:5000`
+- `http://192.168.0.101:5000`
+- `https://192.168.0.101:443`
+
+### Option: `proxy_pass_host`
+
+Determines whether we should pass the host we're running on (for example, 
+`homeassistant.local`) to the server we're proxying to. In general, you probably
+want this to be set to `true`. 
+
+Set to `false` if the server needs to receive the host of the frigate instance
+(not the host Home Assistant or this addon are running on). This might be the case
+if your frigate instance is behind an SSL proxy like (Traefik or Caddy), which
+needs to receive the frigate host in order to route the request correctly.
 
 ## Required Dependencies
 

--- a/frigate_proxy/config.yaml
+++ b/frigate_proxy/config.yaml
@@ -1,5 +1,5 @@
 name: Frigate Proxy
-version: "1.3"
+version: "1.4"
 panel_icon: "mdi:cctv"
 panel_title: Frigate
 slug: frigate-proxy
@@ -24,9 +24,11 @@ tmpfs: false
 full_access: false
 environment: {}
 options:
-  server: "frigate.local:5000"
+  server: "http://frigate.local:5000"
+  proxy_pass_host: true
 schema:
-  server: "match(^.+:\\d+$)"
+  server: "match(^https?://.+:\\d+$)"
+  proxy_pass_host: bool
 services: []
 arch:
   - aarch64

--- a/frigate_proxy/rootfs/etc/cont-init.d/nginx.sh
+++ b/frigate_proxy/rootfs/etc/cont-init.d/nginx.sh
@@ -2,17 +2,14 @@
 # ==============================================================================
 # Configures NGINX for use with this add-on.
 # ==============================================================================
-declare server
+
+# Note the ^ at the beginning of the proxy_pass_host value
+# This stops bashio:var.json from passing the value as a string
 
 bashio::var.json \
     entry "$(bashio::addon.ingress_entry)" \
+    server "$(bashio::config 'server')" \
+    proxy_pass_host "^$(bashio::config 'proxy_pass_host')" \
     | tempio \
         -template /etc/nginx/templates/ingress.gtpl \
         -out /etc/nginx/servers/ingress.conf
-
-server=$(bashio::config 'server')
-
-echo '{"server":"'"$server"'"}' \
-    | tempio \
-        -template /etc/nginx/templates/upstream.gtpl \
-        -out /etc/nginx/includes/upstream.conf

--- a/frigate_proxy/rootfs/etc/nginx/includes/proxy_params.conf
+++ b/frigate_proxy/rootfs/etc/nginx/includes/proxy_params.conf
@@ -7,11 +7,11 @@ proxy_max_temp_file_size    0;
 
 proxy_set_header Accept-Encoding "";
 proxy_set_header Connection $connection_upgrade;
-proxy_set_header Host $http_host;
 proxy_set_header Upgrade $http_upgrade;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $scheme;
 proxy_set_header X-NginX-Proxy true;
 proxy_set_header X-Real-IP $remote_addr;
 
-
+proxy_ssl_server_name on;
+proxy_ssl_session_reuse off;

--- a/frigate_proxy/rootfs/etc/nginx/nginx.conf
+++ b/frigate_proxy/rootfs/etc/nginx/nginx.conf
@@ -39,6 +39,5 @@ http {
         ''      close;
     }
 
-    include /etc/nginx/includes/upstream.conf;
     include /etc/nginx/servers/*.conf;
 }

--- a/frigate_proxy/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/frigate_proxy/rootfs/etc/nginx/templates/ingress.gtpl
@@ -7,8 +7,13 @@ server {
         allow   172.30.32.2;
         deny    all;
 
-        proxy_pass http://backend;
+        proxy_pass {{ .server }};
         proxy_set_header X-Ingress-Path {{ .entry }};
+
+        {{ if .proxy_pass_host }}
+          proxy_set_header Host $http_host;
+        {{ end }}
+
         include /etc/nginx/includes/proxy_params.conf;
     }
 }

--- a/frigate_proxy/rootfs/etc/nginx/templates/upstream.gtpl
+++ b/frigate_proxy/rootfs/etc/nginx/templates/upstream.gtpl
@@ -1,3 +1,0 @@
-upstream backend {
-    server {{ .server }};
-}


### PR DESCRIPTION
- Adds protocol to the server URI to allow specifying an http or https upstream.
- Adds a new configuration variable, `proxy_pass_host`, which determines whether nginx will forward the home assistant host or the frigate upstream host to the upstream in server headers and importantly, as the SSL SNI host.
- Removes the separate `upstream.conf` in nginx, because we weren't (and probably aren't going to) use the load balancing features, and providing the upstream URI directly in the proxy configuration makes switching between http and https easier.
- Updates version number and changelog.

This might require some testing to see how it behaves if someone already using an HTTP server upgrades. It likely requires a configuration update to add `http://` to the beginning of the server option.

This PR addresses #112.

If there are other changes or code style things that need to happen, let me know, I'm happy to take a look.