### PR TITLE
Revert "Reduce capability SYS_ADMIN to PERFMON (#122)"

### DIFF
--- a/frigate/config.yaml
+++ b/frigate/config.yaml
@@ -47,7 +47,7 @@ video: true
 tmpfs: true
 full_access: false
 privileged:
-  - PERFMON
+  - SYS_ADMIN
 environment:
   CONFIG_FILE: /config/frigate.yml
 schema:

--- a/frigate_beta/config.yaml
+++ b/frigate_beta/config.yaml
@@ -47,7 +47,7 @@ video: true
 tmpfs: true
 full_access: false
 privileged:
-  - PERFMON
+  - SYS_ADMIN
 environment:
   CONFIG_FILE: /config/frigate.yml
 schema:

--- a/frigate_fa/config.yaml
+++ b/frigate_fa/config.yaml
@@ -35,7 +35,7 @@ host_network: false
 tmpfs: true
 full_access: true
 privileged:
-  - PERFMON
+  - SYS_ADMIN
 environment:
   CONFIG_FILE: /config/frigate.yml
 schema:

--- a/frigate_fa_beta/config.yaml
+++ b/frigate_fa_beta/config.yaml
@@ -37,7 +37,7 @@ usb: true
 video: true
 full_access: true
 privileged:
-  - PERFMON
+  - SYS_ADMIN
 environment:
   CONFIG_FILE: /config/frigate.yml
 schema:


### PR DESCRIPTION
This reverts commit 3323e7b3c696202787be7ef7b218dec362240207, which does
not seem to be supported across all systems.

Closes https://github.com/blakeblackshear/frigate/issues/8494
