### PR TITLE
Add option to not forward real ip

### DIFF
--- a/frigate_proxy/CHANGELOG.md
+++ b/frigate_proxy/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.5
+
+- Add `proxy_pass_real_ip` option
+
 ### 1.4
 
 - Add support for HTTPS upstream servers

--- a/frigate_proxy/DOCS.md
+++ b/frigate_proxy/DOCS.md
@@ -16,14 +16,21 @@ This must be in the format `http[s]://host:port`. The following are valid exampl
 
 ### Option: `proxy_pass_host`
 
-Determines whether we should pass the host we're running on (for example, 
+Determines whether we should pass the host we're running on (for example,
 `homeassistant.local`) to the server we're proxying to. In general, you probably
-want this to be set to `true`. 
+want this to be set to `true`.
 
 Set to `false` if the server needs to receive the host of the frigate instance
 (not the host Home Assistant or this addon are running on). This might be the case
-if your frigate instance is behind an SSL proxy like (Traefik or Caddy), which
+if your frigate instance is behind an SSL proxy (like Traefik or Caddy), which
 needs to receive the frigate host in order to route the request correctly.
+
+### Option: `proxy_pass_real_ip`
+
+Determines whether we should pass the client's real IP address to the server we're proxying to. In general, you probably
+want this to be set to `true`.
+
+Set to `false` if you need to know the request is coming from the HA IP. This might be the case if your frigate instance is behind a proxy which only allows specific IPs to connect.
 
 ## Required Dependencies
 

--- a/frigate_proxy/config.yaml
+++ b/frigate_proxy/config.yaml
@@ -26,9 +26,11 @@ environment: {}
 options:
   server: "http://frigate.local:5000"
   proxy_pass_host: true
+  proxy_pass_real_ip: true
 schema:
   server: "match(^https?://.+:\\d+$)"
   proxy_pass_host: bool
+  proxy_pass_real_ip: bool
 services: []
 arch:
   - aarch64

--- a/frigate_proxy/config.yaml
+++ b/frigate_proxy/config.yaml
@@ -1,5 +1,5 @@
 name: Frigate Proxy
-version: "1.4"
+version: "1.5"
 panel_icon: "mdi:cctv"
 panel_title: Frigate
 slug: frigate-proxy

--- a/frigate_proxy/rootfs/etc/nginx/includes/proxy_params.conf
+++ b/frigate_proxy/rootfs/etc/nginx/includes/proxy_params.conf
@@ -8,10 +8,8 @@ proxy_max_temp_file_size    0;
 proxy_set_header Accept-Encoding "";
 proxy_set_header Connection $connection_upgrade;
 proxy_set_header Upgrade $http_upgrade;
-proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $scheme;
 proxy_set_header X-NginX-Proxy true;
-proxy_set_header X-Real-IP $remote_addr;
 
 proxy_ssl_server_name on;
 proxy_ssl_session_reuse off;

--- a/frigate_proxy/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/frigate_proxy/rootfs/etc/nginx/templates/ingress.gtpl
@@ -13,6 +13,10 @@ server {
         {{ if .proxy_pass_host }}
           proxy_set_header Host $http_host;
         {{ end }}
+        {{ if .proxy_pass_real_ip }}
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Real-IP $remote_addr;
+        {{ end }}
 
         include /etc/nginx/includes/proxy_params.conf;
     }


### PR DESCRIPTION
Frigate proxy forwards the real ip to the upstream server. This is great in most cases, but advanced configurations, such as Frigate behind a reverse proxy that only allows the HA ip, and relies on HA authentication.
This PR adds the option to not forward the real ip upstream.