### PR TITLE
Fix full access supervisor warning

### DIFF
--- a/frigate_fa/config.yaml
+++ b/frigate_fa/config.yaml
@@ -40,7 +40,6 @@ ports_description:
   1984/tcp: go2rtc API
 host_network: false
 tmpfs: true
-usb: true
 video: true
 full_access: true
 privileged:

--- a/frigate_fa_beta/config.yaml
+++ b/frigate_fa_beta/config.yaml
@@ -53,7 +53,6 @@ ports_description:
   1984/tcp: go2rtc API
 host_network: false
 tmpfs: true
-usb: true
 video: true
 full_access: true
 privileged:


### PR DESCRIPTION
https://developers.home-assistant.io/docs/add-ons/configuration/#:~:text=If%20you%20enable%20this%20option

```
2025-08-21 11:51:59.333 WARNING (SyncWorker_0) [supervisor.addons.validate] Add-on have full device access, and selective device access in the configuration. Please report this to the maintainer of Frigate (Full Access) Beta
2025-08-21 11:51:59.337 WARNING (SyncWorker_0) [supervisor.addons.validate] Add-on have full device access, and selective device access in the configuration. Please report this to the maintainer of Frigate (Full Access)
```