### PR TITLE
Update readme files with correct config filename and directory

### DIFF
--- a/frigate/README.md
+++ b/frigate/README.md
@@ -6,7 +6,7 @@ Please reference the [release notes](https://github.com/blakeblackshear/frigate/
 
 NVR with realtime local object detection for IP cameras.
 
-You must create a config file as `frigate.yml` in the root of your Home Assistant configuration directory.
+You must create a config file as `config.yml` in your add-on configuration folder.
 
 [Documentation](https://docs.frigate.video)
 

--- a/frigate_beta/README.md
+++ b/frigate_beta/README.md
@@ -6,7 +6,7 @@ Please reference the [release notes](https://github.com/blakeblackshear/frigate/
 
 NVR with realtime local object detection for IP cameras.
 
-You must create a config file as `frigate.yml` in the root of your Home Assistant configuration directory.
+You must create a config file as `config.yml` in your add-on configuration folder.
 
 [Documentation](https://docs.frigate.video)
 

--- a/frigate_fa/README.md
+++ b/frigate_fa/README.md
@@ -6,7 +6,7 @@ Please reference the [release notes](https://github.com/blakeblackshear/frigate/
 
 NVR with realtime local object detection for IP cameras.
 
-You must create a config file as `frigate.yml` in the root of your Home Assistant configuration directory.
+You must create a config file as `config.yml` in your add-on configuration folder.
 
 This version of the add-on requests full device access in order to turn off protection mode for those devices which don't work with protection mode enabled.
 

--- a/frigate_fa_beta/README.md
+++ b/frigate_fa_beta/README.md
@@ -6,7 +6,7 @@ Please reference the [release notes](https://github.com/blakeblackshear/frigate/
 
 NVR with realtime local object detection for IP cameras.
 
-You must create a config file as `frigate.yml` in the root of your Home Assistant configuration directory.
+You must create a config file as `config.yml` in your add-on configuration folder.
 
 This version of the add-on requests full device access in order to turn off protection mode for those devices which don't work with protection mode enabled.
 

--- a/frigate_oldcpu/README.md
+++ b/frigate_oldcpu/README.md
@@ -6,7 +6,7 @@ Please reference the [release notes](https://github.com/blakeblackshear/frigate/
 
 NVR with realtime local object detection for IP cameras.
 
-You must create a config file as `frigate.yml` in the root of your Home Assistant configuration directory.
+You must create a config file as `config.yml` in your add-on configuration folder.
 
 [Documentation](https://docs.frigate.video)
 


### PR DESCRIPTION
`config.yml` must now be placed in `/addons_config`.

Using "folder" instead of "directory" because of the note here: https://github.com/home-assistant/supervisor/pull/4650#issuecomment-1781765597