### PR TITLE
Bug fix: Frigate Proxy fails to connect to upstream over HTTPS due to protocol mismatch

### DIFF
--- a/frigate_proxy/rootfs/etc/nginx/includes/proxy_params.conf
+++ b/frigate_proxy/rootfs/etc/nginx/includes/proxy_params.conf
@@ -13,3 +13,6 @@ proxy_set_header X-NginX-Proxy true;
 
 proxy_ssl_server_name on;
 proxy_ssl_session_reuse off;
+# Upstream Frigate-Nginx server only supports TLSv1.3 whilst Nginx version currently used by Frigate-Proxy doesn't include TLSv1.3 by default.
+# https://github.com/blakeblackshear/frigate/blob/b08db4913f72c23638999f30633a91a85bdbee1d/docker/main/rootfs/usr/local/nginx/templates/listen.gotmpl#L21
+proxy_ssl_protocols TLSv1.3;


### PR DESCRIPTION
For better compatibility with potential intermediary proxies it would make sense to allow TLSv1.2 as well, but I'll leave that decision up to you.