### PR TITLE
Clean up list of breaking versions

### DIFF
--- a/frigate/config.yaml
+++ b/frigate/config.yaml
@@ -1,12 +1,8 @@
 name: Frigate
 version: 0.16.2
 breaking_versions:
-  - 0.16.2
-  - 0.16.1
   - 0.16.0
-  - 0.15.1
   - 0.15.0
-  - 0.14.1
   - 0.14.0
 panel_icon: "mdi:cctv"
 panel_title: Frigate

--- a/frigate_beta/config.yaml
+++ b/frigate_beta/config.yaml
@@ -1,26 +1,8 @@
 name: Frigate Beta
 version: 0.16.2
 breaking_versions:
-  - 0.16.2
-  - 0.16.1
   - 0.16.0
-  - 0.16.0-rc4
-  - 0.16.0-rc3
-  - 0.16.0-rc2
-  - 0.16.0-rc1
-  - 0.16.0-beta4
-  - 0.16.0-beta3
-  - 0.16.0-beta2
-  - 0.16.0-beta1
   - 0.15.0
-  - 0.15.0-rc2
-  - 0.15.0-rc1
-  - 0.15.0-beta5
-  - 0.15.0-beta4
-  - 0.15.0-beta3
-  - 0.15.0-beta2
-  - 0.15.0-beta1
-  - 0.14.1
   - 0.14.0
 panel_icon: "mdi:cctv"
 panel_title: Frigate

--- a/frigate_fa/config.yaml
+++ b/frigate_fa/config.yaml
@@ -1,12 +1,8 @@
 name: Frigate (Full Access)
 version: 0.16.2
 breaking_versions:
-  - 0.16.2
-  - 0.16.1
   - 0.16.0
-  - 0.15.1
   - 0.15.0
-  - 0.14.1
   - 0.14.0
 panel_icon: "mdi:cctv"
 panel_title: Frigate

--- a/frigate_fa_beta/config.yaml
+++ b/frigate_fa_beta/config.yaml
@@ -1,25 +1,8 @@
 name: Frigate (Full Access) Beta
 version: 0.16.2
 breaking_versions:
-  - 0.16.2
-  - 0.16.1
-  - 0.16.0-rc4
-  - 0.16.0-rc3
-  - 0.16.0-rc2
-  - 0.16.0-rc1
-  - 0.16.0-beta4
-  - 0.16.0-beta3
-  - 0.16.0-beta2
-  - 0.16.0-beta1
+  - 0.16.0
   - 0.15.0
-  - 0.15.0-rc2
-  - 0.15.0-rc1
-  - 0.15.0-beta5
-  - 0.15.0-beta4
-  - 0.15.0-beta3
-  - 0.15.0-beta2
-  - 0.15.0-beta1
-  - 0.14.1
   - 0.14.0
 panel_icon: "mdi:cctv"
 panel_title: Frigate


### PR DESCRIPTION
As realized [here](https://github.com/blakeblackshear/frigate-hass-addons/pull/221#issuecomment-2809598216), not all individual versions need to be listed in `breaking_versions`.

Supervisor calculates whether an upgrade is breaking or not if there is a breaking version listed in between the current version and the latest version.

For example, if users are in 0.15.1 and latest version is 0.16.2, the 0.16.2 upgrade will be considered breaking because 0.16.0 is in between.